### PR TITLE
v1.2.0: Streaming transcription with pre-warmed worker pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,25 @@ framework) to Home Assistant's Voice pipeline.
 
 - **swift/** — Swift CLI tool that reads PCM audio from stdin and outputs transcribed text as JSON.
   Uses SpeechAnalyzer on macOS 26+ and SFSpeechRecognizer on older systems.
+  With `--worker` it runs as a persistent streaming worker instead: framed JSON commands on
+  stdin (`transcribe` → `audio`+PCM payload → `stop`), `ready`/`partial`/`final`/`error`
+  JSON lines on stdout (`WorkerMode.swift`, `StreamingSession.swift`). The binary must be
+  re-signed after building (`codesign -f -s -`, done by the Makefile) so the embedded
+  Info.plist's speech-recognition usage description is bound into the signature — TCC
+  SIGABRTs the process otherwise. When launched from a terminal/IDE shell, TCC attributes
+  the speech-recognition request to the *responsible process* (the terminal), so test
+  worker mode via launchd (`launchctl submit`) or the installed service.
   - `LocaleMatching.swift` — pure function `bestMatchingLocale(for:in:)` for resolving bare
     language codes (e.g. "en") to full locales (e.g. "en-US") against `SpeechTranscriber.supportedLocales`.
   - `SupportedLanguages.swift` — pure function `languageCodes(from:)` for extracting deduplicated,
     sorted short language codes from a list of locales. Used by `--list-languages` CLI flag.
   - `swift/Tests/AppleSTTTests/` — Swift unit tests (Swift Testing framework).
 - **wyoming_apple_stt/** — Python Wyoming protocol server. Handles TCP connections from Home
-  Assistant, accumulates audio, delegates transcription to the Swift CLI.
+  Assistant. `stt.py` keeps a pool of pre-warmed `apple-stt --worker` processes; the handler
+  streams audio chunks into a worker session as they arrive, forwards partial transcripts as
+  `transcript-chunk` events, and emits the final transcript right after `audio-stop`. Any
+  streaming failure falls back to the buffered one-shot transcription path (audio is always
+  buffered in parallel).
 - **scripts/** — Install and uninstall scripts for the launchd service.
 - **packaging/** — Release tooling: `build-release-tarball.sh` produces the
   GitHub release artifact; `formula.rb.template` + `python-resources.rb` are

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ build: $(SWIFT_BIN) ## Build the Swift CLI binary
 
 $(SWIFT_BIN): swift/Package.swift swift/Sources/AppleSTT/*.swift
 	cd swift && swift build -c release
+	codesign -f -s - $(SWIFT_BIN)
 
 test: venv ## Run Python tests
 	$(VENV_PYTHON) -m pytest tests/ -v
@@ -45,6 +46,7 @@ quality: venv ## Run ruff linter and mypy type checker
 run-clean: venv ## Rebuild Swift binary and start server
 	rm -f $(SWIFT_BIN)
 	cd swift && swift build -c release
+	codesign -f -s - $(SWIFT_BIN)
 	$(VENV_PYTHON) -m wyoming_apple_stt \
 		--uri tcp://0.0.0.0:$(PORT) \
 		--apple-stt-bin $(SWIFT_BIN) \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Every word stays on your Mac: no cloud, no API key, no usage limits, full privac
 
 Both engines run fully on-device. SpeechAnalyzer is faster and more precise.
 
+## Streaming transcription ⚡
+
+Recognition runs **while you are still speaking**, not after. Audio chunks are fed to a
+persistent `apple-stt --worker` process as they arrive from Home Assistant, partial
+transcripts stream back as Wyoming `transcript-chunk` events, and the final transcript is
+ready within milliseconds of the audio ending — instead of paying for a full recognition
+pass at that point.
+
+Workers are pre-warmed: a worker with a loaded recognition model sits idle at all times
+(`--stt-idle-workers`, default 1), and taking one triggers a background replacement spawn
+so concurrent utterances never wait for model initialization. If the streaming path fails
+for any reason, the server transparently falls back to buffered one-shot transcription of
+the same utterance — no audio is lost.
+
+
 ## Install (Homebrew) 🍺
 
 ```bash

--- a/packaging/build-release-tarball.sh
+++ b/packaging/build-release-tarball.sh
@@ -36,6 +36,10 @@ echo "==> Staging tarball contents at ${STAGE_DIR}"
 rm -rf "${STAGE_DIR}" "${TARBALL}"
 mkdir -p "${STAGE_DIR}"
 cp "${BIN_PATH}" "${STAGE_DIR}/apple-stt"
+# Re-sign so the embedded Info.plist (speech-recognition usage description) is
+# bound into the signature; the linker's ad-hoc signature leaves it unbound and
+# TCC then aborts the process on first SFSpeechRecognizer authorization request.
+codesign -f -s - "${STAGE_DIR}/apple-stt"
 cp -R "${REPO_DIR}/wyoming_apple_stt" "${STAGE_DIR}/wyoming_apple_stt"
 cp "${REPO_DIR}/pyproject.toml" "${STAGE_DIR}/pyproject.toml"
 cp "${REPO_DIR}/README.md" "${STAGE_DIR}/README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "wyoming>=1.5.0",
+    "wyoming>=1.8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,6 +38,9 @@ echo "Building Swift CLI..."
 cd "${PROJECT_DIR}/swift"
 swift build -c release
 SWIFT_BIN="${PROJECT_DIR}/swift/.build/release/apple-stt"
+# Re-sign so the embedded Info.plist (speech-recognition usage description) is
+# bound into the signature; TCC SIGABRTs worker mode otherwise.
+codesign -f -s - "${SWIFT_BIN}"
 echo "Built: ${SWIFT_BIN}"
 
 # 2. Stop any running service before overwriting its files. Copying over the

--- a/swift/Sources/AppleSTT/StreamingSession.swift
+++ b/swift/Sources/AppleSTT/StreamingSession.swift
@@ -1,0 +1,296 @@
+import AVFoundation
+import Speech
+
+/// One live streaming transcription: audio is appended as it arrives and partial
+/// transcripts are reported while recognition runs concurrently.
+protocol StreamingSTTSession {
+    /// Append raw PCM audio (16 kHz, 16-bit signed integer, mono).
+    func append(_ pcmData: Data) throws
+
+    /// Signal end of audio and wait for the final transcript.
+    func finish() async throws -> String
+}
+
+/// Streaming session backed by SFSpeechRecognizer (macOS 15+).
+///
+/// Recognition starts immediately and runs while audio is appended;
+/// `onPartial` fires with the cumulative best transcription so far.
+final class SFStreamingSession: StreamingSTTSession, @unchecked Sendable {
+    private let request: SFSpeechAudioBufferRecognitionRequest
+    private let recognizer: SFSpeechRecognizer
+    private var task: SFSpeechRecognitionTask?
+
+    private let stateLock = NSLock()
+    private var completedResult: Result<String, Error>?
+    private var finalContinuation: CheckedContinuation<String, Error>?
+    private var lastPartialText = ""
+
+    init(language: String, onPartial: @escaping (String) -> Void) throws {
+        let (locale, recognizer) = try Self.resolveOnDeviceRecognizer(for: language)
+        self.recognizer = recognizer
+        fputs("[apple-stt] Using recognizer locale \(locale.identifier)\n", stderr)
+
+        request = SFSpeechAudioBufferRecognitionRequest()
+        request.requiresOnDeviceRecognition = true
+        request.shouldReportPartialResults = true
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+
+            if let result {
+                let text = result.bestTranscription.formattedString
+                if result.isFinal {
+                    self.complete(.success(text))
+                } else {
+                    self.stateLock.lock()
+                    self.lastPartialText = text
+                    self.stateLock.unlock()
+                    onPartial(text)
+                }
+                return
+            }
+
+            if let error {
+                // "No speech detected" after endAudio is a normal empty result,
+                // not a failure; and if we already heard words, keep them rather
+                // than discarding the utterance over a finalization hiccup.
+                self.stateLock.lock()
+                let heardText = self.lastPartialText
+                self.stateLock.unlock()
+                if !heardText.isEmpty {
+                    self.complete(.success(heardText))
+                } else if (error as NSError).code == 1110 {
+                    self.complete(.success(""))
+                } else {
+                    self.complete(
+                        .failure(STTError.recognitionFailed(error.localizedDescription)))
+                }
+            }
+        }
+    }
+
+    /// Resolve a language to a locale whose on-device model is actually installed.
+    ///
+    /// `SFSpeechRecognizer.supportedLocales()` is an unordered set, so simply
+    /// taking the first same-language locale can land on a regional variant with
+    /// no downloaded model (e.g. "en" → "en-GB"). This prefers an exact BCP-47
+    /// match, then any same-language locale that supports on-device recognition,
+    /// scanned in deterministic (sorted) order.
+    ///
+    /// - Parameter language: BCP-47 language code (e.g. "en", "de-DE").
+    /// - Returns: The chosen locale and its recognizer.
+    /// - Throws: `STTError.languageNotSupported` if no locale matches the
+    ///   language at all, or `STTError.onDeviceModelNotAvailable` if one matches
+    ///   but no on-device model is installed for it.
+    private static func resolveOnDeviceRecognizer(
+        for language: String
+    ) throws -> (Locale, SFSpeechRecognizer) {
+        let supported = Array(SFSpeechRecognizer.supportedLocales())
+        let candidate = Locale(identifier: language)
+        let candidateBCP47 = candidate.identifier(.bcp47)
+
+        let exact = supported.filter { $0.identifier(.bcp47) == candidateBCP47 }
+        let sameLanguage = supported
+            .filter {
+                $0.identifier(.bcp47) != candidateBCP47
+                    && $0.language.languageCode == candidate.language.languageCode
+            }
+            .sorted { $0.identifier(.bcp47) < $1.identifier(.bcp47) }
+        let ordered = exact + sameLanguage
+
+        guard !ordered.isEmpty else {
+            throw STTError.languageNotSupported(language)
+        }
+
+        for locale in ordered {
+            if let recognizer = SFSpeechRecognizer(locale: locale),
+                recognizer.supportsOnDeviceRecognition
+            {
+                return (locale, recognizer)
+            }
+        }
+
+        throw STTError.onDeviceModelNotAvailable
+    }
+
+    func append(_ pcmData: Data) throws {
+        guard let buffer = try makePCMBuffer(from: pcmData) else { return }
+        request.append(buffer)
+    }
+
+    func finish() async throws -> String {
+        request.endAudio()
+
+        // Safety net: some on-device recognizer configurations stop calling back
+        // after endAudio() without ever delivering an isFinal result, which would
+        // hang finish() forever. The streamed partials already hold the full text,
+        // so if no final arrives shortly we finalize with the last partial.
+        let fallback = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+            self.complete(.success(self.snapshotLastPartial()))
+        }
+
+        let result = try await withCheckedThrowingContinuation { continuation in
+            stateLock.lock()
+            if let result = completedResult {
+                stateLock.unlock()
+                continuation.resume(with: result)
+            } else {
+                finalContinuation = continuation
+                stateLock.unlock()
+            }
+        }
+        fallback.cancel()
+        return result
+    }
+
+    /// Thread-safe read of the most recent partial transcription.
+    private func snapshotLastPartial() -> String {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return lastPartialText
+    }
+
+    /// Deliver the final result exactly once, whether finish() is already waiting or not.
+    private func complete(_ result: Result<String, Error>) {
+        stateLock.lock()
+        guard completedResult == nil else {
+            stateLock.unlock()
+            return
+        }
+        completedResult = result
+        let continuation = finalContinuation
+        finalContinuation = nil
+        stateLock.unlock()
+
+        continuation?.resume(with: result)
+    }
+}
+
+/// Streaming session backed by SpeechAnalyzer (macOS 26+).
+///
+/// Volatile results stream out as partials while finalized segments accumulate
+/// into the final transcript.
+@available(macOS 26, *)
+final class AnalyzerStreamingSession: StreamingSTTSession {
+    private let analyzer: SpeechAnalyzer
+    private let analyzerFormat: AVAudioFormat
+    private let converter: AVAudioConverter?
+    private let inputContinuation: AsyncStream<AnalyzerInput>.Continuation
+    private let resultTask: Task<String, Error>
+
+    init(language: String, onPartial: @escaping @Sendable (String) -> Void) async throws {
+        guard SpeechTranscriber.isAvailable else {
+            throw STTError.recognitionFailed("SpeechTranscriber is not available on this system.")
+        }
+
+        let supported = await SpeechTranscriber.supportedLocales
+        let installed = await SpeechTranscriber.installedLocales
+        // Prefer a locale whose model is already installed, so a bare "en"
+        // doesn't resolve to an uninstalled regional variant when another is ready.
+        guard
+            let locale = bestMatchingLocale(for: language, in: installed)
+                ?? bestMatchingLocale(for: language, in: supported)
+        else {
+            throw STTError.languageNotSupported(language)
+        }
+
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults],
+            attributeOptions: []
+        )
+
+        let localeBCP47 = locale.identifier(.bcp47)
+        if !installed.contains(where: { $0.identifier(.bcp47) == localeBCP47 }) {
+            if let downloader = try await AssetInventory.assetInstallationRequest(
+                supporting: [transcriber]
+            ) {
+                fputs("[apple-stt] Downloading model for \(locale)...\n", stderr)
+                try await downloader.downloadAndInstall()
+            }
+        }
+
+        guard
+            let format = await SpeechAnalyzer.bestAvailableAudioFormat(
+                compatibleWith: [transcriber]
+            )
+        else {
+            throw STTError.recognitionFailed(
+                "No compatible audio format available for SpeechAnalyzer.")
+        }
+        analyzerFormat = format
+        converter = format == pcmInputFormat ? nil : AVAudioConverter(from: pcmInputFormat, to: format)
+
+        resultTask = Task {
+            var finalizedText = ""
+            for try await result in transcriber.results {
+                let text = String(result.text.characters)
+                if result.isFinal {
+                    finalizedText = finalizedText.isEmpty ? text : finalizedText + " " + text
+                    onPartial(finalizedText)
+                } else if !text.isEmpty {
+                    let partial = finalizedText.isEmpty ? text : finalizedText + " " + text
+                    onPartial(partial)
+                }
+            }
+            return finalizedText
+        }
+
+        let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+        inputContinuation = continuation
+        analyzer = SpeechAnalyzer(modules: [transcriber])
+        try await analyzer.start(inputSequence: stream)
+    }
+
+    func append(_ pcmData: Data) throws {
+        guard let inputBuffer = try makePCMBuffer(from: pcmData) else { return }
+
+        guard let converter else {
+            inputContinuation.yield(AnalyzerInput(buffer: inputBuffer))
+            return
+        }
+
+        let outputCapacity = AVAudioFrameCount(
+            (Double(inputBuffer.frameLength) * analyzerFormat.sampleRate
+                / pcmInputFormat.sampleRate).rounded(.up) + 64
+        )
+        guard
+            let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: analyzerFormat, frameCapacity: outputCapacity)
+        else {
+            throw STTError.bufferCreationFailed
+        }
+
+        // Streaming conversion: hand over this chunk once, then report "ran dry"
+        // so the converter returns what it has and keeps its internal state for
+        // the next chunk (sample-rate converters carry filter history across calls).
+        nonisolated(unsafe) var inputSupplied = false
+        var conversionError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &conversionError) {
+            _, outStatus in
+            if inputSupplied {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            inputSupplied = true
+            outStatus.pointee = .haveData
+            return inputBuffer
+        }
+        if status == .error {
+            throw STTError.recognitionFailed(
+                conversionError?.localizedDescription ?? "Audio conversion failed.")
+        }
+        if outputBuffer.frameLength > 0 {
+            inputContinuation.yield(AnalyzerInput(buffer: outputBuffer))
+        }
+    }
+
+    func finish() async throws -> String {
+        inputContinuation.finish()
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+        return try await resultTask.value
+    }
+}

--- a/swift/Sources/AppleSTT/SupportedLanguages.swift
+++ b/swift/Sources/AppleSTT/SupportedLanguages.swift
@@ -16,3 +16,22 @@ func languageCodes(from locales: [Locale]) -> [String] {
     }
     return seen.sorted()
 }
+
+/// Filter locales to those whose dictation model is actually installed.
+///
+/// Pre-Tahoe systems have no API to download speech models on demand, so
+/// only locales that already support on-device recognition can transcribe.
+/// Falls back to the unfiltered list when nothing is installed, so callers
+/// never advertise an empty language list.
+///
+/// - Parameters:
+///   - locales: Candidate locales, typically `SFSpeechRecognizer.supportedLocales()`.
+///   - isInstalled: Returns true when the locale's on-device model is available.
+/// - Returns: The installed subset, or all locales if that subset is empty.
+func dictationReadyLocales(
+    from locales: [Locale],
+    isInstalled: (Locale) -> Bool
+) -> [Locale] {
+    let installed = locales.filter(isInstalled)
+    return installed.isEmpty ? locales : installed
+}

--- a/swift/Sources/AppleSTT/WorkerMode.swift
+++ b/swift/Sources/AppleSTT/WorkerMode.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+/// Serializes stdout writes in worker mode: partial-transcript callbacks fire on
+/// recognition threads while the main loop owns the command flow.
+private let workerStdoutLock = NSLock()
+
+/// Write one worker-protocol frame (a JSON header line) to stdout.
+func writeWorkerFrame(_ header: [String: Any]) {
+    var data = try! JSONSerialization.data(withJSONObject: header)
+    data.append(0x0A)
+
+    workerStdoutLock.lock()
+    defer { workerStdoutLock.unlock() }
+    FileHandle.standardOutput.write(data)
+}
+
+/// Buffered stdin reader for the worker protocol: JSON header lines followed by
+/// binary audio payloads (which may contain newline bytes, so `readLine()` can't
+/// be used). Reads run one at a time from the worker loop; the class is not
+/// safe for concurrent readers.
+final class StdinFrameReader: @unchecked Sendable {
+    private var buffer = Data()
+    private let chunkSize = 65536
+
+    /// Read one newline-terminated header line. Returns nil on EOF.
+    func readHeaderLine() -> Data? {
+        while true {
+            if let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                let line = buffer.subdata(in: buffer.startIndex..<newlineIndex)
+                buffer.removeSubrange(buffer.startIndex...newlineIndex)
+                return line
+            }
+            guard fill() else {
+                return buffer.isEmpty ? nil : buffer
+            }
+        }
+    }
+
+    /// Read exactly `count` payload bytes. Returns nil on premature EOF.
+    func readExactly(_ count: Int) -> Data? {
+        while buffer.count < count {
+            guard fill() else { return nil }
+        }
+        let payload = buffer.prefix(count)
+        buffer.removeFirst(count)
+        return Data(payload)
+    }
+
+    /// Pull more bytes from stdin into the buffer. Returns false on EOF.
+    ///
+    /// Uses read(2) directly because `FileHandle.readData(ofLength:)` loops
+    /// until it accumulates the full requested length, which deadlocks the
+    /// framed protocol whenever a frame boundary leaves fewer bytes pending.
+    private func fill() -> Bool {
+        var chunk = [UInt8](repeating: 0, count: chunkSize)
+        var bytesRead = 0
+        repeat {
+            bytesRead = chunk.withUnsafeMutableBytes { read(0, $0.baseAddress, chunkSize) }
+        } while bytesRead < 0 && errno == EINTR
+        guard bytesRead > 0 else { return false }
+        buffer.append(contentsOf: chunk[0..<bytesRead])
+        return true
+    }
+}
+
+/// A command frame received on stdin in worker mode.
+private struct WorkerCommand: Decodable {
+    let type: String
+    let language: String?
+    let length: Int?
+}
+
+/// Read the next command frame off stdin without blocking the cooperative pool.
+private func readCommand(_ reader: StdinFrameReader) async -> WorkerCommand? {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            guard let line = reader.readHeaderLine(), !line.isEmpty else {
+                continuation.resume(returning: nil)
+                return
+            }
+            continuation.resume(
+                returning: try? JSONDecoder().decode(WorkerCommand.self, from: line))
+        }
+    }
+}
+
+/// Read an audio payload off stdin without blocking the cooperative pool.
+private func readPayload(_ reader: StdinFrameReader, length: Int) async -> Data? {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            continuation.resume(returning: reader.readExactly(length))
+        }
+    }
+}
+
+/// Open a streaming session on the best engine for this macOS version.
+private func makeStreamingSession(
+    language: String,
+    onPartial: @escaping @Sendable (String) -> Void
+) async throws -> StreamingSTTSession {
+    if #available(macOS 26, *) {
+        do {
+            return try await AnalyzerStreamingSession(language: language, onPartial: onPartial)
+        } catch {
+            fputs(
+                "[apple-stt] SpeechAnalyzer session failed, falling back to "
+                    + "SFSpeechRecognizer: \(error.localizedDescription)\n",
+                stderr)
+        }
+    }
+    return try SFStreamingSession(language: language, onPartial: onPartial)
+}
+
+/// Run one transcription session: consume audio frames until `stop`, streaming
+/// partial transcripts out as recognition progresses, then emit the final text.
+private func runSession(reader: StdinFrameReader, language: String) async {
+    fputs("[apple-stt] Session start (language=\(language))\n", stderr)
+    let session: StreamingSTTSession
+    do {
+        session = try await makeStreamingSession(language: language) { partialText in
+            writeWorkerFrame(["type": "partial", "text": partialText])
+        }
+    } catch {
+        fputs("[apple-stt] Session init failed: \(error.localizedDescription)\n", stderr)
+        // Drain this session's frames so the stream stays in sync for the next one.
+        while let command = await readCommand(reader), command.type != "stop" {
+            if command.type == "audio", let length = command.length {
+                _ = await readPayload(reader, length: length)
+            }
+        }
+        writeWorkerFrame(["type": "error", "message": error.localizedDescription])
+        return
+    }
+
+    while let command = await readCommand(reader) {
+        switch command.type {
+        case "audio":
+            guard let length = command.length, length > 0,
+                let payload = await readPayload(reader, length: length)
+            else { continue }
+            do {
+                try session.append(payload)
+            } catch {
+                fputs("[apple-stt] Dropping audio chunk: \(error.localizedDescription)\n", stderr)
+            }
+        case "stop":
+            do {
+                let text = try await session.finish()
+                writeWorkerFrame(["type": "final", "text": text])
+            } catch {
+                writeWorkerFrame(["type": "error", "message": error.localizedDescription])
+            }
+            return
+        default:
+            writeWorkerFrame(["type": "error", "message": "unexpected frame: \(command.type)"])
+            return
+        }
+    }
+}
+
+/// Force the recognition model for a language into memory with a short discarded
+/// session, so the first real request doesn't pay the lazy-load cost.
+private func warmUp(language: String) async {
+    do {
+        let session = try await makeStreamingSession(language: language) { _ in }
+        try session.append(Data(count: 3200))  // 100 ms of silence
+        _ = try await session.finish()
+        fputs("[apple-stt] Warmed up recognition for '\(language)'\n", stderr)
+    } catch {
+        fputs("[apple-stt] Warmup for '\(language)' failed: \(error.localizedDescription)\n", stderr)
+    }
+}
+
+/// Run the persistent worker loop: authorize, warm up, signal readiness, then
+/// serve transcription sessions from stdin until EOF.
+func runWorkerMode(language: String) async {
+    do {
+        try await requestAuthorization()
+    } catch {
+        fputs("Error: \(error.localizedDescription)\n", stderr)
+        exit(1)
+    }
+
+    await warmUp(language: language)
+    writeWorkerFrame(["type": "ready"])
+
+    let reader = StdinFrameReader()
+    while let command = await readCommand(reader) {
+        guard command.type == "transcribe" else {
+            writeWorkerFrame(["type": "error", "message": "expected transcribe frame"])
+            continue
+        }
+        await runSession(reader: reader, language: command.language ?? language)
+    }
+}

--- a/swift/Sources/AppleSTT/main.swift
+++ b/swift/Sources/AppleSTT/main.swift
@@ -124,11 +124,18 @@ let cliArgs = parseArgs()
 if cliArgs.listLanguages {
     var codes: [String]
     if #available(macOS 26, *) {
+        // SpeechAnalyzer can download missing models via AssetInventory,
+        // so every supported locale is genuinely usable.
         let locales = await SpeechTranscriber.supportedLocales
         codes = languageCodes(from: locales)
     } else {
-        let locales = Array(SFSpeechRecognizer.supportedLocales())
-        codes = languageCodes(from: locales)
+        // SFSpeechRecognizer cannot trigger model downloads, so only
+        // advertise locales whose dictation model is already installed.
+        let supported = Array(SFSpeechRecognizer.supportedLocales())
+        let ready = dictationReadyLocales(from: supported) { locale in
+            SFSpeechRecognizer(locale: locale)?.supportsOnDeviceRecognition == true
+        }
+        codes = languageCodes(from: ready)
     }
     if let jsonData = try? JSONSerialization.data(withJSONObject: codes),
         let jsonString = String(data: jsonData, encoding: .utf8)

--- a/swift/Sources/AppleSTT/main.swift
+++ b/swift/Sources/AppleSTT/main.swift
@@ -39,6 +39,8 @@ struct CLIArgs {
     var listLanguages: Bool = false
     /// When true, download/ensure the language model and exit (no transcription).
     var preload: Bool = false
+    /// When true, run as a persistent streaming worker (framed protocol on stdin/stdout).
+    var worker: Bool = false
 }
 
 /// Parse command-line arguments.
@@ -56,6 +58,9 @@ func parseArgs() -> CLIArgs {
             i += 1
         } else if args[i] == "--preload" {
             result.preload = true
+            i += 1
+        } else if args[i] == "--worker" {
+            result.worker = true
             i += 1
         } else {
             i += 1
@@ -147,6 +152,11 @@ if cliArgs.preload {
     }
     // SFSpeechRecognizer has no downloadable-asset API here; nothing to preload.
     fputs("[apple-stt] Preload is a no-op on macOS < 26\n", stderr)
+    exit(0)
+}
+
+if cliArgs.worker {
+    await runWorkerMode(language: cliArgs.language)
     exit(0)
 }
 

--- a/swift/Tests/AppleSTTTests/SupportedLanguagesTests.swift
+++ b/swift/Tests/AppleSTTTests/SupportedLanguagesTests.swift
@@ -45,3 +45,37 @@ struct SupportedLanguagesTests {
         #expect(codes == ["zh"])
     }
 }
+
+@Suite("dictationReadyLocales")
+struct DictationReadyLocalesTests {
+
+    @Test("keeps only locales the predicate marks installed")
+    func filtersToInstalled() {
+        let locales = [
+            Locale(identifier: "de-DE"),
+            Locale(identifier: "fr-FR"),
+            Locale(identifier: "en-US"),
+        ]
+        let installed: Set<String> = ["de-DE", "en-US"]
+        let ready = dictationReadyLocales(from: locales) {
+            installed.contains($0.identifier(.bcp47))
+        }
+        #expect(ready.map { $0.identifier(.bcp47) } == ["de-DE", "en-US"])
+    }
+
+    @Test("falls back to all locales when none are installed")
+    func fallbackWhenNoneInstalled() {
+        let locales = [
+            Locale(identifier: "de-DE"),
+            Locale(identifier: "fr-FR"),
+        ]
+        let ready = dictationReadyLocales(from: locales) { _ in false }
+        #expect(ready == locales)
+    }
+
+    @Test("empty input returns empty array")
+    func emptyInput() {
+        let ready = dictationReadyLocales(from: []) { _ in true }
+        #expect(ready.isEmpty)
+    }
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,11 @@ import asyncio
 import logging
 from unittest.mock import AsyncMock, Mock, patch
 
-from wyoming_apple_stt.__main__ import _discover_languages, _preload_model
+from wyoming_apple_stt.__main__ import (
+    _build_asr_program,
+    _discover_languages,
+    _preload_model,
+)
 
 
 async def test_preload_model_invokes_cli_with_preload_flag(caplog):
@@ -87,3 +91,9 @@ async def test_preload_model_timeout_kills_process(caplog):
 
     mock_process.kill.assert_called_once()
     assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_asr_program_advertises_transcript_streaming():
+    program = _build_asr_program(["en", "de"])
+    assert program.supports_transcript_streaming is True
+    assert program.models[0].languages == ["en", "de"]

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -1,0 +1,238 @@
+"""Tests for the streaming STT module: worker protocol, sessions, and the pool."""
+
+import asyncio
+import stat
+
+import pytest
+
+from wyoming_apple_stt.stt import (
+    SttWorker,
+    SttWorkerError,
+    SttWorkerPool,
+)
+
+# A stand-in for `apple-stt --worker`: prints ready, then serves transcription
+# sessions. Each audio frame produces a partial with the cumulative decoded
+# text; stop produces a final with the full text. Payload "explode" triggers
+# an error frame at stop, "die" kills the process immediately.
+FAKE_WORKER = """#!/usr/bin/env python3
+import json, os, sys
+
+def frame(header):
+    sys.stdout.buffer.write(json.dumps(header).encode() + b"\\n")
+    sys.stdout.buffer.flush()
+
+if "--fail-start" in sys.argv:
+    sys.exit(1)
+
+frame({"type": "ready"})
+
+while True:
+    line = sys.stdin.buffer.readline()
+    if not line:
+        break
+    command = json.loads(line)
+    assert command["type"] == "transcribe"
+    received = b""
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            sys.exit(0)
+        command = json.loads(line)
+        if command["type"] == "audio":
+            received += sys.stdin.buffer.read(command["length"])
+            if b"die" in received:
+                os._exit(1)
+            frame({"type": "partial", "text": received.decode(errors="replace")})
+        elif command["type"] == "stop":
+            if b"explode" in received:
+                frame({"type": "error", "message": "recognizer refused"})
+            elif b"stall" in received:
+                pass  # never answer: simulates a hung recognizer
+            else:
+                frame({"type": "final", "text": received.decode(errors="replace")})
+            break
+"""
+
+
+@pytest.fixture
+def fake_worker_bin(tmp_path):
+    """Write the fake apple-stt worker script and return its path."""
+    path = tmp_path / "fake-apple-stt"
+    path.write_text(FAKE_WORKER)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+# --- SttWorker / SttSession ---
+
+
+async def test_worker_start_ready(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        assert worker.is_alive
+    finally:
+        await worker.stop()
+
+
+async def test_worker_start_failure_raises():
+    worker = SttWorker("/nonexistent/apple-stt", language="en")
+    with pytest.raises(SttWorkerError):
+        await worker.start(timeout=5)
+
+
+async def test_worker_exit_before_ready_raises(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en", extra_args=["--fail-start"])
+    with pytest.raises(SttWorkerError):
+        await worker.start(timeout=5)
+
+
+async def test_session_streams_partials_and_final(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"hello ")
+        await session.send_audio(b"world")
+
+        partials = []
+
+        async def collect():
+            async for text in session.partials():
+                partials.append(text)
+
+        collector = asyncio.create_task(collect())
+        final = await session.finish(timeout=10)
+        await collector
+
+        assert final == "hello world"
+        assert partials == ["hello ", "hello world"]
+        assert worker.is_alive
+    finally:
+        await worker.stop()
+
+
+async def test_worker_serves_multiple_sessions(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        for text in (b"first", b"second"):
+            session = await worker.transcribe(language="en")
+            await session.send_audio(text)
+            assert await session.finish(timeout=10) == text.decode()
+        assert worker.is_alive
+    finally:
+        await worker.stop()
+
+
+async def test_session_error_frame_raises_but_worker_survives(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"explode")
+        with pytest.raises(SttWorkerError, match="recognizer refused"):
+            await session.finish(timeout=10)
+        # The protocol stayed in sync, so the worker remains usable.
+        assert worker.is_alive
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"ok")
+        assert await session.finish(timeout=10) == "ok"
+    finally:
+        await worker.stop()
+
+
+async def test_worker_death_midsession_raises(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"die")
+        with pytest.raises(SttWorkerError):
+            await session.finish(timeout=10)
+        assert not worker.is_alive
+    finally:
+        await worker.stop()
+
+
+async def test_finish_timeout_marks_worker_unusable(fake_worker_bin):
+    worker = SttWorker(fake_worker_bin, language="en")
+    await worker.start(timeout=10)
+    try:
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"stall")
+        with pytest.raises(SttWorkerError):
+            await session.finish(timeout=0.2)
+        # The worker may still hold unread frames, so it must not be reused.
+        assert not worker.is_alive
+    finally:
+        await worker.stop()
+
+
+# --- SttWorkerPool ---
+
+
+async def test_pool_prewarms_idle_worker(fake_worker_bin):
+    pool = SttWorkerPool(fake_worker_bin, language="en", idle_target=1)
+    await pool.start()
+    try:
+        assert len(pool._idle) == 1
+        assert pool._idle[0].is_alive
+    finally:
+        await pool.stop()
+
+
+async def test_pool_acquire_returns_warm_worker_and_replenishes(fake_worker_bin):
+    pool = SttWorkerPool(fake_worker_bin, language="en", idle_target=1)
+    await pool.start()
+    try:
+        warm_worker = pool._idle[0]
+        worker = await pool.acquire()
+        assert worker is warm_worker  # no spawn wait on the request path
+
+        # A replacement spawn was scheduled in the background.
+        await asyncio.gather(*pool._spawn_tasks)
+        assert len(pool._idle) == 1
+        assert pool._idle[0] is not worker
+
+        await pool.release(worker)
+        # Pool is full again, so the released worker is disposed.
+        assert len(pool._idle) == 1
+        assert not worker.is_alive
+    finally:
+        await pool.stop()
+
+
+async def test_pool_acquire_spawns_when_empty(fake_worker_bin):
+    pool = SttWorkerPool(fake_worker_bin, language="en", idle_target=1)
+    # No start(): pool is empty, acquire must spawn synchronously.
+    worker = await pool.acquire()
+    try:
+        assert worker.is_alive
+    finally:
+        await pool.release(worker)
+        await pool.stop()
+
+
+async def test_pool_release_disposes_dead_worker(fake_worker_bin):
+    pool = SttWorkerPool(fake_worker_bin, language="en", idle_target=2)
+    await pool.start()
+    try:
+        worker = await pool.acquire()
+        session = await worker.transcribe(language="en")
+        await session.send_audio(b"die")
+        with pytest.raises(SttWorkerError):
+            await session.finish(timeout=10)
+        await pool.release(worker)
+        assert worker not in pool._idle
+    finally:
+        await pool.stop()
+
+
+async def test_pool_stop_kills_idle_workers(fake_worker_bin):
+    pool = SttWorkerPool(fake_worker_bin, language="en", idle_target=1)
+    await pool.start()
+    worker = pool._idle[0]
+    await pool.stop()
+    assert not worker.is_alive

--- a/tests/test_stt_handler.py
+++ b/tests/test_stt_handler.py
@@ -1,0 +1,311 @@
+"""Tests for the streaming STT side of the Wyoming event handler."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from wyoming.asr import (
+    Transcribe,
+    Transcript,
+    TranscriptChunk,
+    TranscriptStart,
+    TranscriptStop,
+)
+from wyoming.audio import AudioChunk, AudioStop
+
+from wyoming_apple_stt.handler import AppleSTTEventHandler
+from wyoming_apple_stt.stt import SttService, SttWorkerError
+
+
+class FakeSession:
+    """In-memory stand-in for an SttSession."""
+
+    def __init__(self, worker: "FakeSttWorker") -> None:
+        self._worker = worker
+        self.audio = b""
+        self.partial_texts: list[str] = []
+        self.fail_send: str | None = None
+        self.fail_finish: str | None = None
+        self.finished = False
+
+    async def send_audio(self, pcm: bytes) -> None:
+        if self.fail_send:
+            raise SttWorkerError(self.fail_send)
+        self.audio += pcm
+        self.partial_texts.append(self.audio.decode(errors="replace"))
+
+    async def finish(self, timeout: float = 30) -> str:
+        self.finished = True
+        if self.fail_finish:
+            self._worker.is_alive = False
+            raise SttWorkerError(self.fail_finish)
+        return self.audio.decode(errors="replace")
+
+    async def partials(self):
+        for text in self.partial_texts:
+            yield text
+
+
+class FakeSttWorker:
+    """In-memory stand-in for an SttWorker."""
+
+    def __init__(self) -> None:
+        self.is_alive = True
+        self.stopped = False
+        self.sessions: list[FakeSession] = []
+
+    async def transcribe(self, language=None) -> FakeSession:
+        session = FakeSession(self)
+        self.sessions.append(session)
+        return session
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.is_alive = False
+
+
+class FakeSttPool:
+    """In-memory stand-in for an SttWorkerPool."""
+
+    def __init__(self) -> None:
+        self.workers: list[FakeSttWorker] = []
+        self.released: list[FakeSttWorker] = []
+        self.fail_acquire = False
+
+    async def acquire(self) -> FakeSttWorker:
+        if self.fail_acquire:
+            raise SttWorkerError("no worker available")
+        worker = FakeSttWorker()
+        self.workers.append(worker)
+        return worker
+
+    async def release(self, worker) -> None:
+        self.released.append(worker)
+        if not worker.is_alive:
+            worker.stopped = True
+
+
+@pytest.fixture
+def stt_service() -> SttService:
+    return SttService(pool=FakeSttPool(), timeout=5)
+
+
+@pytest.fixture
+def stt_handler(wyoming_info, cli_args, stt_service):
+    """Create a handler with streaming STT enabled and mocked reader/writer."""
+    reader = AsyncMock()
+    writer = AsyncMock()
+    handler = AppleSTTEventHandler(
+        wyoming_info,
+        cli_args,
+        asyncio.Lock(),
+        reader,
+        writer,
+        stt_service=stt_service,
+    )
+    handler.write_event = AsyncMock()
+    return handler
+
+
+def written_events(handler) -> list:
+    return [call.args[0] for call in handler.write_event.call_args_list]
+
+
+async def run_utterance(handler, chunks: list[bytes]) -> bool:
+    """Push one full utterance through the handler."""
+    await handler.handle_event(Transcribe(language="en").event())
+    for chunk in chunks:
+        event = AudioChunk(rate=16000, width=2, channels=1, audio=chunk).event()
+        await handler.handle_event(event)
+    return await handler.handle_event(AudioStop().event())
+
+
+async def test_streaming_flow_emits_envelope_and_partials(stt_handler, stt_service):
+    """Chunks stream to the worker; partials and final go out as events."""
+    result = await run_utterance(stt_handler, [b"hello ", b"world"])
+    assert result is False
+
+    events = written_events(stt_handler)
+    types = [event.type for event in events]
+    assert types[0] == TranscriptStart().event().type
+    assert types[-2:] == [Transcript(text="").event().type, TranscriptStop().event().type]
+
+    chunk_texts = [
+        TranscriptChunk.from_event(event).text
+        for event in events
+        if TranscriptChunk.is_type(event.type)
+    ]
+    assert chunk_texts == ["hello ", "hello world"]
+
+    final = Transcript.from_event(events[-2])
+    assert final.text == "hello world"
+
+    # The worker went back to the pool.
+    pool = stt_service.pool
+    assert pool.workers[0] in pool.released
+    assert pool.workers[0].sessions[0].finished
+
+
+async def test_acquire_failure_falls_back_to_buffered(stt_handler, stt_service):
+    """When no worker can be acquired, the old one-shot path still answers."""
+    stt_service.pool.fail_acquire = True
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (
+        json.dumps({"text": "fallback text"}).encode(),
+        b"",
+    )
+    mock_process.returncode = 0
+
+    with patch(
+        "wyoming_apple_stt.handler.asyncio.create_subprocess_exec",
+        return_value=mock_process,
+    ):
+        result = await run_utterance(stt_handler, [b"\x00\x00" * 100])
+
+    assert result is False
+    events = written_events(stt_handler)
+    finals = [Transcript.from_event(e) for e in events if Transcript.is_type(e.type)]
+    assert finals[0].text == "fallback text"
+    # Streaming is still advertised, so the envelope is kept.
+    assert any(TranscriptStart.is_type(e.type) for e in events)
+    assert TranscriptStop.is_type(events[-1].type)
+
+
+async def test_finish_failure_falls_back_to_buffered(stt_handler, stt_service):
+    """A worker error at finish falls back to the buffered transcription."""
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (
+        json.dumps({"text": "buffered result"}).encode(),
+        b"",
+    )
+    mock_process.returncode = 0
+
+    await stt_handler.handle_event(Transcribe(language="en").event())
+    event = AudioChunk(rate=16000, width=2, channels=1, audio=b"speech").event()
+    await stt_handler.handle_event(event)
+
+    session = stt_service.pool.workers[0].sessions[0]
+    session.fail_finish = "recognizer exploded"
+
+    with patch(
+        "wyoming_apple_stt.handler.asyncio.create_subprocess_exec",
+        return_value=mock_process,
+    ):
+        result = await stt_handler.handle_event(AudioStop().event())
+
+    assert result is False
+    events = written_events(stt_handler)
+    finals = [Transcript.from_event(e) for e in events if Transcript.is_type(e.type)]
+    assert finals[0].text == "buffered result"
+    # The broken worker was handed back for disposal, not reused.
+    worker = stt_service.pool.workers[0]
+    assert worker in stt_service.pool.released
+    assert not worker.is_alive
+
+
+async def test_send_failure_mid_stream_falls_back(stt_handler, stt_service):
+    """A pipe failure while streaming audio tears the session down once and
+    the buffered fallback still transcribes the full utterance."""
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (
+        json.dumps({"text": "recovered"}).encode(),
+        b"",
+    )
+    mock_process.returncode = 0
+
+    await stt_handler.handle_event(Transcribe(language="en").event())
+    first = AudioChunk(rate=16000, width=2, channels=1, audio=b"first").event()
+    await stt_handler.handle_event(first)
+
+    stt_service.pool.workers[0].sessions[0].fail_send = "pipe broke"
+
+    second = AudioChunk(rate=16000, width=2, channels=1, audio=b"second").event()
+    await stt_handler.handle_event(second)
+    # No new session is opened after the failure.
+    assert len(stt_service.pool.workers) == 1
+
+    with patch(
+        "wyoming_apple_stt.handler.asyncio.create_subprocess_exec",
+        return_value=mock_process,
+    ) as mock_exec:
+        result = await stt_handler.handle_event(AudioStop().event())
+
+    assert result is False
+    # The buffered fallback got the full audio, including the failed chunk.
+    sent_audio = mock_process.communicate.call_args.kwargs.get("input") or b""
+    assert b"first" in sent_audio and b"second" in sent_audio
+    assert mock_exec.called
+    finals = [
+        Transcript.from_event(e)
+        for e in written_events(stt_handler)
+        if Transcript.is_type(e.type)
+    ]
+    assert finals[0].text == "recovered"
+
+
+async def test_no_stt_service_keeps_legacy_shape(wyoming_info, cli_args):
+    """Without an SttService the handler behaves exactly as before."""
+    handler = AppleSTTEventHandler(
+        wyoming_info, cli_args, asyncio.Lock(), AsyncMock(), AsyncMock()
+    )
+    handler.write_event = AsyncMock()
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (
+        json.dumps({"text": "legacy"}).encode(),
+        b"",
+    )
+    mock_process.returncode = 0
+
+    with patch(
+        "wyoming_apple_stt.handler.asyncio.create_subprocess_exec",
+        return_value=mock_process,
+    ):
+        result = await run_utterance(handler, [b"\x00\x00" * 100])
+
+    assert result is False
+    events = written_events(handler)
+    assert len(events) == 1
+    assert Transcript.from_event(events[0]).text == "legacy"
+
+
+async def test_disconnect_stops_held_worker(stt_handler, stt_service):
+    """A client dropping mid-utterance must not leak the session's worker."""
+    await stt_handler.handle_event(Transcribe(language="en").event())
+    event = AudioChunk(rate=16000, width=2, channels=1, audio=b"speech").event()
+    await stt_handler.handle_event(event)
+
+    worker = stt_service.pool.workers[0]
+    await stt_handler.disconnect()
+    assert worker.stopped
+
+
+async def test_second_utterance_after_failure_streams_again(stt_handler, stt_service):
+    """A session failure only affects its own utterance."""
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (json.dumps({"text": "x"}).encode(), b"")
+    mock_process.returncode = 0
+
+    await stt_handler.handle_event(Transcribe(language="en").event())
+    event = AudioChunk(rate=16000, width=2, channels=1, audio=b"boom").event()
+    await stt_handler.handle_event(event)
+    stt_service.pool.workers[0].sessions[0].fail_finish = "boom"
+    with patch(
+        "wyoming_apple_stt.handler.asyncio.create_subprocess_exec",
+        return_value=mock_process,
+    ):
+        await stt_handler.handle_event(AudioStop().event())
+
+    stt_handler.write_event.reset_mock()
+
+    result = await run_utterance(stt_handler, [b"clean run"])
+    assert result is False
+    finals = [
+        Transcript.from_event(e)
+        for e in written_events(stt_handler)
+        if Transcript.is_type(e.type)
+    ]
+    assert finals[0].text == "clean run"
+    assert len(stt_service.pool.workers) == 2

--- a/wyoming_apple_stt/__main__.py
+++ b/wyoming_apple_stt/__main__.py
@@ -11,6 +11,7 @@ from wyoming.info import AsrModel, AsrProgram, Attribution, Info
 from wyoming.server import AsyncServer
 
 from .handler import AppleSTTEventHandler
+from .stt import SttService, SttWorkerPool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -115,6 +116,41 @@ async def _preload_model(bin_path: str, language: str) -> None:
         )
 
 
+_APPLE_STT_ATTRIBUTION = Attribution(
+    name="Apple",
+    url="https://developer.apple.com/documentation/speech",
+)
+
+
+def _build_asr_program(languages: list[str]) -> AsrProgram:
+    """Describe the Apple STT service for Wyoming Info.
+
+    Args:
+        languages: BCP-47 language codes the recognizer supports.
+
+    Returns:
+        An AsrProgram advertising streaming transcription support.
+    """
+    return AsrProgram(
+        name="apple-stt",
+        description="Apple on-device speech recognition",
+        attribution=_APPLE_STT_ATTRIBUTION,
+        installed=True,
+        version=None,
+        supports_transcript_streaming=True,
+        models=[
+            AsrModel(
+                name="apple-stt",
+                description="Apple on-device speech recognition",
+                attribution=_APPLE_STT_ATTRIBUTION,
+                installed=True,
+                languages=languages,
+                version=None,
+            )
+        ],
+    )
+
+
 async def main() -> None:
     """Parse args, build Info, and start the Wyoming server."""
     parser = argparse.ArgumentParser(
@@ -148,6 +184,12 @@ async def main() -> None:
         help="Max audio duration to buffer in seconds (default: 60)",
     )
     parser.add_argument(
+        "--stt-idle-workers",
+        type=int,
+        default=1,
+        help="Number of pre-warmed STT worker processes to keep ready (default: 1)",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -165,32 +207,21 @@ async def main() -> None:
     await _preload_model(args.apple_stt_bin, args.language)
 
     wyoming_info = Info(
-        asr=[
-            AsrProgram(
-                name="apple-stt",
-                description="Apple on-device speech recognition",
-                attribution=Attribution(
-                    name="Apple",
-                    url="https://developer.apple.com/documentation/speech",
-                ),
-                installed=True,
-                version=None,
-                models=[
-                    AsrModel(
-                        name="apple-stt",
-                        description="Apple on-device speech recognition",
-                        attribution=Attribution(
-                            name="Apple",
-                            url="https://developer.apple.com/documentation/speech",
-                        ),
-                        installed=True,
-                        languages=languages,
-                        version=None,
-                    )
-                ],
-            )
-        ],
+        asr=[_build_asr_program(languages)],
     )
+
+    stt_service = SttService(
+        pool=SttWorkerPool(
+            args.apple_stt_bin,
+            language=args.language,
+            idle_target=args.stt_idle_workers,
+        ),
+        timeout=args.timeout,
+    )
+    _LOGGER.info(
+        "Pre-warming %d STT worker process(es)...", args.stt_idle_workers
+    )
+    await stt_service.pool.start()
 
     lock = asyncio.Lock()
     server = AsyncServer.from_uri(args.uri)
@@ -201,7 +232,18 @@ async def main() -> None:
         args.language,
     )
 
-    await server.run(partial(AppleSTTEventHandler, wyoming_info, args, lock))
+    try:
+        await server.run(
+            partial(
+                AppleSTTEventHandler,
+                wyoming_info,
+                args,
+                lock,
+                stt_service=stt_service,
+            )
+        )
+    finally:
+        await stt_service.pool.stop()
 
 
 def run() -> None:

--- a/wyoming_apple_stt/handler.py
+++ b/wyoming_apple_stt/handler.py
@@ -6,11 +6,19 @@ import json
 import logging
 from typing import Any, Optional
 
-from wyoming.asr import Transcribe, Transcript
+from wyoming.asr import (
+    Transcribe,
+    Transcript,
+    TranscriptChunk,
+    TranscriptStart,
+    TranscriptStop,
+)
 from wyoming.audio import AudioChunk, AudioChunkConverter, AudioStop
 from wyoming.event import Event
 from wyoming.info import Describe, Info
 from wyoming.server import AsyncEventHandler
+
+from .stt import SttService, SttSession, SttWorker, SttWorkerError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +37,7 @@ class AppleSTTEventHandler(AsyncEventHandler):
         cli_args: argparse.Namespace,
         transcription_lock: asyncio.Lock,
         *args: Any,
+        stt_service: Optional[SttService] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -42,6 +51,13 @@ class AppleSTTEventHandler(AsyncEventHandler):
             rate=16000, width=2, channels=1
         )
         self._max_audio_bytes = cli_args.max_audio_seconds * 16000 * 2  # 16kHz * 16-bit
+
+        self._stt = stt_service
+        self._stt_worker: Optional[SttWorker] = None
+        self._stt_session: Optional[SttSession] = None
+        self._stt_partial_task: Optional[asyncio.Task] = None
+        self._stt_session_failed = False
+        self._transcript_started = False
 
     async def handle_event(self, event: Event) -> bool:
         """Handle a Wyoming protocol event.
@@ -57,6 +73,8 @@ class AppleSTTEventHandler(AsyncEventHandler):
             self._language = transcribe.language
             self._audio_bytes.clear()
             self._buffer_full_warned = False
+            self._stt_session_failed = False
+            self._transcript_started = False
             return True
 
         if AudioChunk.is_type(event.type):
@@ -67,17 +85,133 @@ class AppleSTTEventHandler(AsyncEventHandler):
             elif not self._buffer_full_warned:
                 _LOGGER.warning("Max audio buffer reached, dropping audio")
                 self._buffer_full_warned = True
+            await self._stream_audio_to_worker(chunk.audio)
             return True
 
         if AudioStop.is_type(event.type):
-            text = await self._transcribe()
+            text = await self._finish_streaming_transcription()
+            if text is None:
+                text = await self._transcribe()
+            if self._stt is not None and not self._transcript_started:
+                await self.write_event(
+                    TranscriptStart(language=self._language).event()
+                )
+                self._transcript_started = True
             await self.write_event(Transcript(text=text).event())
+            if self._stt is not None:
+                await self.write_event(TranscriptStop().event())
             self._audio_bytes.clear()
             self._buffer_full_warned = False
             self._language = None
+            self._transcript_started = False
             return False
 
         return True
+
+    async def disconnect(self) -> None:
+        """Dispose of a held worker when the client drops mid-request.
+
+        A worker abandoned mid-transcription has unread frames in its pipe
+        and cannot be reused, so it is stopped rather than released.
+        """
+        if self._stt_session is not None or self._stt_worker is not None:
+            await self._teardown_stt_session()
+
+    async def _stream_audio_to_worker(self, audio: bytes) -> None:
+        """Feed one audio chunk to the streaming session, opening it lazily.
+
+        The first chunk of an utterance acquires a pre-warmed worker and opens
+        a transcription session on it. Any failure marks the session as failed
+        for the rest of the utterance; the buffered one-shot path then answers
+        at AudioStop, so streaming problems never lose the utterance.
+        """
+        if self._stt is None or self._stt_session_failed:
+            return
+
+        if self._stt_session is None:
+            try:
+                self._stt_worker = await self._stt.pool.acquire()
+                self._stt_session = await self._stt_worker.transcribe(
+                    language=self._language or self._cli_args.language
+                )
+            except SttWorkerError as exc:
+                _LOGGER.warning(
+                    "Streaming STT unavailable, using buffered fallback: %s", exc
+                )
+                await self._teardown_stt_session()
+                return
+            self._stt_partial_task = asyncio.create_task(
+                self._forward_partials(self._stt_session)
+            )
+            _LOGGER.debug("Streaming transcription session opened")
+
+        try:
+            await self._stt_session.send_audio(audio)
+        except SttWorkerError as exc:
+            _LOGGER.warning(
+                "Streaming STT failed mid-utterance, using buffered fallback: %s", exc
+            )
+            await self._teardown_stt_session()
+
+    async def _forward_partials(self, session: SttSession) -> None:
+        """Forward the session's partial transcripts to the client as they arrive."""
+        async for text in session.partials():
+            if not self._transcript_started:
+                await self.write_event(
+                    TranscriptStart(language=self._language).event()
+                )
+                self._transcript_started = True
+            await self.write_event(TranscriptChunk(text=text).event())
+
+    async def _finish_streaming_transcription(self) -> Optional[str]:
+        """Finalize the streaming session and return its transcript.
+
+        Returns:
+            The final text, or None when no session is open or it failed —
+            the caller then falls back to the buffered one-shot path.
+        """
+        if self._stt_session is None:
+            return None
+        assert self._stt is not None
+
+        session, self._stt_session = self._stt_session, None
+        try:
+            text: Optional[str] = await session.finish(timeout=self._stt.timeout)
+        except SttWorkerError as exc:
+            _LOGGER.warning(
+                "Streaming transcription failed, using buffered fallback: %s", exc
+            )
+            text = None
+
+        if self._stt_partial_task is not None:
+            task, self._stt_partial_task = self._stt_partial_task, None
+            if text is None:
+                task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        if self._stt_worker is not None:
+            worker, self._stt_worker = self._stt_worker, None
+            await self._stt.pool.release(worker)
+        return text
+
+    async def _teardown_stt_session(self) -> None:
+        """Dispose of a failed session's worker and disable streaming until
+        the next utterance."""
+        self._stt_session_failed = True
+        self._stt_session = None
+        if self._stt_partial_task is not None:
+            task, self._stt_partial_task = self._stt_partial_task, None
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if self._stt_worker is not None:
+            worker, self._stt_worker = self._stt_worker, None
+            await worker.stop()
 
     async def _transcribe(self) -> str:
         """Run the apple-stt subprocess and return transcribed text."""

--- a/wyoming_apple_stt/stt.py
+++ b/wyoming_apple_stt/stt.py
@@ -1,0 +1,379 @@
+"""Streaming STT support: the apple-stt worker protocol and the warm worker pool."""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+_LOGGER = logging.getLogger(__name__)
+
+# Pipe buffer limit for worker stdout; header lines are small but partials
+# can carry long transcripts.
+_STREAM_LIMIT = 1024 * 1024
+
+
+class SttWorkerError(Exception):
+    """Raised when a worker fails to start, dies, or reports a session error."""
+
+
+class SttSession:
+    """One live transcription on a worker: audio in, partials and a final out.
+
+    Created by SttWorker.transcribe(). A background reader task dispatches
+    the worker's frames: "partial" texts go to the partials() iterator and
+    the "final" (or "error") frame resolves finish().
+    """
+
+    def __init__(self, worker: "SttWorker") -> None:
+        self._worker = worker
+        self._partials: asyncio.Queue[Optional[str]] = asyncio.Queue()
+        self._final: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        self._reader_task = asyncio.create_task(self._read_frames())
+
+    async def send_audio(self, pcm: bytes) -> None:
+        """Feed one chunk of raw PCM audio (16 kHz, 16-bit, mono) to the worker.
+
+        Args:
+            pcm: Raw audio bytes; empty chunks are ignored.
+
+        Raises:
+            SttWorkerError: When the worker is gone or the pipe write fails.
+        """
+        if not pcm:
+            return
+        await self._worker._write_frame({"type": "audio", "length": len(pcm)}, pcm)
+
+    async def finish(self, timeout: float = 30) -> str:
+        """Signal end of audio and wait for the final transcript.
+
+        Args:
+            timeout: Max seconds to wait for the worker's final frame.
+
+        Returns:
+            The final transcript text.
+
+        Raises:
+            SttWorkerError: When the worker reports an error, dies, or the
+                final frame does not arrive in time (the worker is marked
+                broken in the latter cases, so the pool disposes of it).
+        """
+        try:
+            await self._worker._write_frame({"type": "stop"})
+        except SttWorkerError:
+            pass  # The reader task will surface the underlying failure.
+
+        try:
+            return await asyncio.wait_for(asyncio.shield(self._final), timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            self._worker._broken = True
+            self._reader_task.cancel()
+            self._close_partials()
+            raise SttWorkerError(f"transcription timed out after {timeout}s") from exc
+
+    async def partials(self) -> AsyncIterator[str]:
+        """Yield partial transcripts as the worker produces them.
+
+        The iterator ends when the session's final (or error) frame arrives.
+        """
+        while (text := await self._partials.get()) is not None:
+            yield text
+
+    async def _read_frames(self) -> None:
+        """Dispatch worker frames until the session completes or fails."""
+        try:
+            while True:
+                header = await self._worker._read_header()
+                frame_type = header.get("type")
+                if frame_type == "partial":
+                    self._partials.put_nowait(str(header.get("text", "")))
+                elif frame_type == "final":
+                    self._resolve_final(text=str(header.get("text", "")))
+                    return
+                elif frame_type == "error":
+                    self._resolve_final(
+                        error=SttWorkerError(
+                            header.get("message", "unknown transcription error")
+                        )
+                    )
+                    return
+                else:
+                    self._worker._broken = True
+                    self._resolve_final(
+                        error=SttWorkerError(f"unexpected worker frame: {header}")
+                    )
+                    return
+        except SttWorkerError as exc:
+            self._worker._broken = True
+            self._resolve_final(error=exc)
+        except asyncio.CancelledError:
+            pass
+
+    def _resolve_final(
+        self, text: Optional[str] = None, error: Optional[SttWorkerError] = None
+    ) -> None:
+        """Complete the final future once and end the partials iterator."""
+        if not self._final.done():
+            if error is not None:
+                self._final.set_exception(error)
+            else:
+                self._final.set_result(text or "")
+        self._close_partials()
+
+    def _close_partials(self) -> None:
+        """Signal the end of the partials iterator."""
+        self._partials.put_nowait(None)
+
+
+class SttWorker:
+    """One `apple-stt --worker` subprocess with a preloaded recognition model.
+
+    The worker is started once, keeps its model warm for its lifetime, and
+    serves one transcription session at a time over its stdin/stdout pipe.
+    """
+
+    def __init__(
+        self,
+        bin_path: str,
+        language: str = "en",
+        extra_args: Optional[list[str]] = None,
+    ) -> None:
+        self._bin_path = bin_path
+        self._language = language
+        self._extra_args = extra_args or []
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._stderr_task: Optional[asyncio.Task] = None
+        self._broken = False
+
+    @property
+    def is_alive(self) -> bool:
+        """Whether the worker process is running and its protocol is in sync."""
+        return (
+            not self._broken
+            and self._process is not None
+            and self._process.returncode is None
+        )
+
+    async def start(self, timeout: float = 60) -> None:
+        """Launch the worker and wait until its recognition model is warm.
+
+        Args:
+            timeout: Max seconds to wait for the worker's ready signal.
+
+        Raises:
+            SttWorkerError: When the worker cannot be launched or never
+                becomes ready.
+        """
+        command = [self._bin_path, "--worker", "--language", self._language]
+        command += self._extra_args
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=_STREAM_LIMIT,
+            )
+        except OSError as exc:
+            raise SttWorkerError(f"failed to launch {self._bin_path}: {exc}") from exc
+
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+        try:
+            header = await asyncio.wait_for(self._read_header(), timeout=timeout)
+        except (asyncio.TimeoutError, SttWorkerError) as exc:
+            await self.stop()
+            raise SttWorkerError(f"worker did not become ready: {exc}") from exc
+
+        if header.get("type") != "ready":
+            await self.stop()
+            raise SttWorkerError(f"unexpected worker greeting: {header}")
+
+        _LOGGER.debug("STT worker ready (pid %s)", self._process.pid)
+
+    async def transcribe(self, language: Optional[str] = None) -> SttSession:
+        """Open a transcription session on this worker.
+
+        Args:
+            language: BCP-47 language code; defaults to the worker's language.
+
+        Returns:
+            The live session; feed it audio and call finish().
+
+        Raises:
+            SttWorkerError: When the worker is not running.
+        """
+        if not self.is_alive:
+            raise SttWorkerError("worker is not running")
+        await self._write_frame(
+            {"type": "transcribe", "language": language or self._language}
+        )
+        return SttSession(self)
+
+    async def stop(self) -> None:
+        """Terminate the worker process and clean up."""
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+
+        if self._process is None:
+            return
+        process, self._process = self._process, None
+        if process.returncode is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+
+    async def _write_frame(self, header: dict, payload: bytes = b"") -> None:
+        """Write one header line plus optional binary payload to the worker."""
+        if not self.is_alive:
+            raise SttWorkerError("worker is not running")
+        assert self._process is not None and self._process.stdin is not None
+        try:
+            self._process.stdin.write(json.dumps(header).encode() + b"\n" + payload)
+            await self._process.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError, OSError) as exc:
+            self._broken = True
+            raise SttWorkerError(f"worker pipe closed: {exc}") from exc
+
+    async def _read_header(self) -> dict:
+        """Read one JSON header line from the worker's stdout."""
+        assert self._process is not None and self._process.stdout is not None
+        line = await self._process.stdout.readline()
+        if not line:
+            raise SttWorkerError("worker closed its output (process died?)")
+        try:
+            header: dict = json.loads(line)
+            return header
+        except json.JSONDecodeError as exc:
+            raise SttWorkerError(f"invalid worker frame: {line[:200]!r}") from exc
+
+    async def _drain_stderr(self) -> None:
+        """Forward the worker's stderr lines to the debug log."""
+        assert self._process is not None and self._process.stderr is not None
+        try:
+            while line := await self._process.stderr.readline():
+                _LOGGER.debug("%s", line.decode(errors="replace").rstrip())
+        except (asyncio.CancelledError, ValueError):
+            pass
+
+
+class SttWorkerPool:
+    """Keeps pre-warmed apple-stt workers so recognition starts with zero delay.
+
+    The pool maintains idle_target idle workers with warm recognition models.
+    acquire() hands out a warm worker and immediately begins spawning a
+    replacement in the background, so a concurrent second request never
+    waits for model initialization.
+    """
+
+    def __init__(
+        self,
+        bin_path: str,
+        language: str = "en",
+        idle_target: int = 1,
+    ) -> None:
+        self._bin_path = bin_path
+        self._language = language
+        self._idle_target = max(1, idle_target)
+        self._idle: list[SttWorker] = []
+        self._spawning = 0
+        self._spawn_tasks: set[asyncio.Task] = set()
+        self._closed = False
+
+    async def start(self) -> None:
+        """Pre-warm the initial idle workers, waiting until they are ready."""
+        workers = await asyncio.gather(
+            *(self._spawn_worker() for _ in range(self._idle_target)),
+            return_exceptions=True,
+        )
+        for worker in workers:
+            if isinstance(worker, BaseException):
+                _LOGGER.warning("Failed to pre-warm STT worker: %s", worker)
+            else:
+                self._idle.append(worker)
+
+    async def acquire(self) -> SttWorker:
+        """Take a warm worker, triggering a background replacement spawn.
+
+        Returns:
+            A ready worker. The caller must hand it back via release().
+
+        Raises:
+            SttWorkerError: When no worker is available and a fresh spawn fails.
+        """
+        worker: Optional[SttWorker] = None
+        while self._idle and worker is None:
+            candidate = self._idle.pop()
+            if candidate.is_alive:
+                worker = candidate
+            else:
+                await candidate.stop()
+
+        self._replenish()
+
+        if worker is None:
+            worker = await self._spawn_worker()
+        return worker
+
+    async def release(self, worker: SttWorker) -> None:
+        """Return a worker to the pool, or dispose of it if surplus or dead."""
+        if self._closed or not worker.is_alive or len(self._idle) >= self._idle_target:
+            await worker.stop()
+        else:
+            self._idle.append(worker)
+
+    async def stop(self) -> None:
+        """Shut down all idle workers and cancel pending spawns."""
+        self._closed = True
+        for task in self._spawn_tasks:
+            task.cancel()
+        self._spawn_tasks.clear()
+        idle, self._idle = self._idle, []
+        await asyncio.gather(*(worker.stop() for worker in idle))
+
+    def _replenish(self) -> None:
+        """Spawn background workers until the idle target is covered."""
+        if self._closed:
+            return
+        while len(self._idle) + self._spawning < self._idle_target:
+            self._spawning += 1
+            task = asyncio.create_task(self._spawn_into_pool())
+            self._spawn_tasks.add(task)
+            task.add_done_callback(self._spawn_tasks.discard)
+
+    async def _spawn_into_pool(self) -> None:
+        """Spawn one worker and park it in the idle pool."""
+        try:
+            worker = await self._spawn_worker()
+        except SttWorkerError as exc:
+            _LOGGER.warning("Failed to spawn replacement STT worker: %s", exc)
+            return
+        finally:
+            self._spawning -= 1
+
+        if self._closed or len(self._idle) >= self._idle_target:
+            await worker.stop()
+        else:
+            self._idle.append(worker)
+
+    async def _spawn_worker(self) -> SttWorker:
+        """Create and start one worker for the pool's language."""
+        worker = SttWorker(self._bin_path, self._language)
+        await worker.start()
+        return worker
+
+
+@dataclass
+class SttService:
+    """Everything the event handler needs to serve streaming STT requests."""
+
+    pool: SttWorkerPool
+    timeout: float = 30.0


### PR DESCRIPTION
Syncs main with the released v1.2.0 (already tagged and published to Homebrew from develop).

- Streaming transcription contributed by @DerPicknicker (#4): persistent `--worker` processes, live `transcript-chunk` partials, pre-warmed worker pool, buffered fallback
- Review fixes: install.sh binary signing, wyoming>=1.8.0 floor
- Binary re-signing in Makefile and release tarball; pre-Tahoe `--list-languages` filtered to installed models

Verified: 37 Python + 16 Swift tests, sandboxed install, live end-to-end streaming test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3ZZU8C83XBRdBHe2yZS79