### PR TITLE
v2.0.1 — advertise Wyoming programs as apple-speech

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def wyoming_info() -> Info:
     return Info(
         asr=[
             AsrProgram(
-                name="apple-stt",
+                name="apple-speech",
                 description="Apple on-device speech recognition",
                 attribution=Attribution(
                     name="Apple",
@@ -22,7 +22,7 @@ def wyoming_info() -> Info:
                 version=None,
                 models=[
                     AsrModel(
-                        name="apple-stt",
+                        name="apple-speech",
                         description="Apple on-device speech recognition",
                         attribution=Attribution(
                             name="Apple",

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -42,7 +42,7 @@ async def test_describe_returns_info(handler, wyoming_info):
     written_event = handler.write_event.call_args[0][0]
     info = Info.from_event(written_event)
     assert len(info.asr) == 1
-    assert info.asr[0].name == "apple-stt"
+    assert info.asr[0].name == "apple-speech"
     assert info.asr[0].models[0].languages == ["en"]
 
 

--- a/wyoming_apple_speech/__main__.py
+++ b/wyoming_apple_speech/__main__.py
@@ -150,7 +150,7 @@ def _build_asr_program(languages: list[str]) -> AsrProgram:
         An AsrProgram advertising streaming transcription support.
     """
     return AsrProgram(
-        name="apple-stt",
+        name="apple-speech",
         description="Apple on-device speech recognition",
         attribution=_APPLE_STT_ATTRIBUTION,
         installed=True,
@@ -158,7 +158,7 @@ def _build_asr_program(languages: list[str]) -> AsrProgram:
         supports_transcript_streaming=True,
         models=[
             AsrModel(
-                name="apple-stt",
+                name="apple-speech",
                 description="Apple on-device speech recognition",
                 attribution=_APPLE_STT_ATTRIBUTION,
                 installed=True,
@@ -179,7 +179,7 @@ def _build_tts_program(voices: list[SiriVoice]) -> TtsProgram:
         A TtsProgram advertising streaming synthesis support.
     """
     return TtsProgram(
-        name="apple-tts",
+        name="apple-speech",
         description="Apple Siri on-device text-to-speech",
         attribution=_APPLE_TTS_ATTRIBUTION,
         installed=True,


### PR DESCRIPTION
Patch release: the Wyoming `Info` programs (what Home Assistant displays as the engine name) still said `apple-stt`/`apple-tts` after the project rename. Both now advertise as `apple-speech`. Binary names unchanged. 72/72 tests, ruff + mypy clean.

Note for upgraders: HA registers the entities under the new name — re-select the STT/TTS engine in your Assist pipeline once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgEMUdF2PNywdnyfzn4E89