### PR TITLE
v2.0.3 — self-diagnosing Full Disk Access failures

### DIFF
--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import stat
+import sys
 
 import pytest
 
@@ -209,6 +210,19 @@ async def test_worker_start_failure_raises():
     failing = TtsWorker("/nonexistent/apple-tts")
     with pytest.raises(TtsWorkerError):
         await failing.start(timeout=5)
+
+
+async def test_worker_immediate_death_hints_full_disk_access(tmp_path):
+    """A worker dying before its ready line is the Full Disk Access signature:
+    the error must name the fix and the exact Python binary to grant."""
+    path = tmp_path / "dying-apple-tts"
+    path.write_text("#!/bin/sh\nexit 1\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+    worker = TtsWorker(str(path))
+    with pytest.raises(TtsWorkerError, match="Full Disk Access") as excinfo:
+        await worker.start(timeout=10)
+    assert sys.executable in str(excinfo.value)
 
 
 # --- TtsWorkerPool ---

--- a/wyoming_apple_speech/tts.py
+++ b/wyoming_apple_speech/tts.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import re
+import sys
 from dataclasses import dataclass
 from typing import AsyncIterator, Optional
 
@@ -236,7 +237,20 @@ class TtsWorker:
             header = await asyncio.wait_for(self._read_header(), timeout=timeout)
         except (asyncio.TimeoutError, TtsWorkerError) as exc:
             await self.stop()
-            raise TtsWorkerError(f"worker did not become ready: {exc}") from exc
+            message = f"worker did not become ready: {exc}"
+            if not isinstance(exc, asyncio.TimeoutError):
+                # The worker's output pipe broke, i.e. the process died at
+                # startup — the signature of the Python binary lacking Full
+                # Disk Access (Siri voices load a TCC-protected model cache).
+                message += (
+                    " — a TTS worker dying at startup usually means the Python"
+                    f" running this server ({sys.executable}) lacks Full Disk"
+                    " Access. Grant it in System Settings → Privacy & Security"
+                    " → Full Disk Access and restart the service; re-grant"
+                    " after every Python upgrade (the path changes). See the"
+                    " README's TTS section."
+                )
+            raise TtsWorkerError(message) from exc
 
         if header.get("type") != "ready":
             await self.stop()


### PR DESCRIPTION
When a TTS worker dies at startup (the signature of the service's Python losing Full Disk Access, which happens on every Python upgrade), the error now names the fix and the exact binary to grant instead of the generic "worker closed its output". TDD'd; 73/73 tests, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKtX3ybs42gz6aNAU9BL77